### PR TITLE
Remove path to galois solver

### DIFF
--- a/src/ore_algebra/ore_algebra.py
+++ b/src/ore_algebra/ore_algebra.py
@@ -1691,8 +1691,9 @@ class OreAlgebra_generic(UniqueRepresentation, Algebra):
         solver = nullspace.kronecker(nullspace.gauss()) # good for ZZ[x...] and GF(p)[x...]
         if B is QQ:
             solver = nullspace.clear(solver) # good for QQ[x...]
-        elif is_NumberField(B):
-            solver = nullspace.galois(solver) # good for QQ(alpha)[x...]
+        # elif is_NumberField(B):
+        #     solver = nullspace.galois(solver)
+        #     # good for QQ(alpha)[x...] but not implemented
         elif not (B is ZZ or B.characteristic() > 0):
             solver = nullspace.sage_native # for lack of better ideas
 


### PR DESCRIPTION
Hi,

Running various algorithms on Ore polynomials with coefficients in a number field raises a NotImplementedError because it tries to call the "galois" solver.

The patch falls back to the native solver.

Example:
```
from ore_algebra import OreAlgebra
Pol.<x> = PolynomialRing(QQ)
OreD.<Dx> = OreAlgebra(Pol)
L = x^2*Dx^2 + x*Dx + 1
QQa.<a> = QQ.extension(x^2+1)
LL = L.change_ring(Pol.change_ring(QQa))
LL.annihilator_of_composition(1/x)
```

