### PR TITLE
Tentative fix for annihilator of composition in char p

### DIFF
--- a/src/ore_algebra/ore_operator_1_1.py
+++ b/src/ore_algebra/ore_operator_1_1.py
@@ -3810,8 +3810,7 @@ class UnivariateRecurrenceOperatorOverUnivariateRing(UnivariateOreOperatorOverUn
             # a is constant => f(a) is constant => S-1 kills it
             return A.gen() - A.one()
 
-        K = a.parent().base_ring()
-        R = K[A.base_ring().gen()]
+        R = QQ[A.base_ring().gen()]
 
         try:
             a = R(a)
@@ -3895,11 +3894,12 @@ class UnivariateRecurrenceOperatorOverUnivariateRing(UnivariateOreOperatorOverUn
         ops = [A(self)] + list(map(A, list(other)))
         S_power = A.associated_commutative_algebra().gen()**len(ops)
         x = A.base_ring().gen()
+        x_Q = QQ[x].gen()
 
         for i in range(len(ops)):
             ops[i] = A(ops[i].polynomial()(S_power)\
                        .map_coefficients(lambda p: p(x/len(ops))))\
-                       .annihilator_of_composition(x - i)
+                       .annihilator_of_composition(x_Q - i)
 
         return self.parent()(reduce(lambda p, q: p.lclm(q), ops).numerator())
 

--- a/src/ore_algebra/ore_operator_1_1.py
+++ b/src/ore_algebra/ore_operator_1_1.py
@@ -3810,7 +3810,8 @@ class UnivariateRecurrenceOperatorOverUnivariateRing(UnivariateOreOperatorOverUn
             # a is constant => f(a) is constant => S-1 kills it
             return A.gen() - A.one()
 
-        R = QQ[A.base_ring().gen()]
+        K = a.parent().base_ring()
+        R = K[A.base_ring().gen()]
 
         try:
             a = R(a)


### PR DESCRIPTION
Hi Manuel,

This commit fixes the bug with annihilator_of_composition when dealing with data in a finite field.

There are other occurrences of QQ being hardcoded in the later code, but Sage accepts to convert Fp into QQ, so no error is raised. Changing those forced conversions would cause problems down the line, because finite field elements don't have a numerator and a denominator. On the other hand, doing the computations in QQ is safe, because Sage converts the finite field elements into positive integers (no denominator, no fractional part, non-negative). And if the matrix solver is invoked, it will be in Fp anyway.

More test is probably needed before merging.

Best wishes,
Thibaut

Edit: coerce -> convert