### PR TITLE
Change of vars

### DIFF
--- a/src/ore_algebra/ore_operator_1_1.py
+++ b/src/ore_algebra/ore_operator_1_1.py
@@ -2004,7 +2004,7 @@ class UnivariateDifferentialOperatorOverUnivariateRing(UnivariateOreOperatorOver
             -x^2*Dx
             sage: print(conv(x*Dx))
             -x*Dx
-            sage: print(conv(conv(x*Dx))) # identity since 1/1/x = 1
+            sage: print(conv(conv(x*Dx))) # identity since 1/1/x = x
             x*Dx
             sage: LL, conv = L.change_of_variables(1+x^2)
             sage: print(LL)

--- a/src/ore_algebra/ore_operator_1_1.py
+++ b/src/ore_algebra/ore_operator_1_1.py
@@ -1976,8 +1976,11 @@ class UnivariateDifferentialOperatorOverUnivariateRing(UnivariateOreOperatorOver
 
         OUTPUT:
 
-        - ``L`` -- an Ore operator such that for all ``f`` annihilated by ``self``, ``L`` annihilates ``f \circ a``.
-        - ``conv`` -- a function which takes as input an Ore operator ``A`` and returns an Ore operator ``B`` such that for all functions ``f`` annihilated by ``self``, ``A(f)(a(x)) = B(f(a(x)))``.
+        - ``L`` -- an Ore operator such that for all ``f`` annihilated by
+        ``self``, ``L`` annihilates ``f \circ a``.
+        - ``conv`` -- a function which takes as input an Ore operator ``A`` and
+          returns an Ore operator ``B`` such that for all functions ``f``
+          annihilated by ``self``, ``A(f)(a(x)) = B(f(a(x)))``.
 
         EXAMPLES:
 

--- a/src/ore_algebra/ore_operator_1_1.py
+++ b/src/ore_algebra/ore_operator_1_1.py
@@ -1974,7 +1974,7 @@ class UnivariateDifferentialOperatorOverUnivariateRing(UnivariateOreOperatorOver
         OUTPUT:
 
         - ``L`` -- an Ore operator such that for all ``f`` annihilated by ``self``, ``L`` annihilates ``f \circ a``.
-        - ``conv`` -- a function which takes as input an Ore operator ``A`` and returns an Ore operator ``B`` such that for all functions ``f`` annihilated by ``f``, ``A(f)(a(x)) = B(f(a(x)))``.
+        - ``conv`` -- a function which takes as input an Ore operator ``A`` and returns an Ore operator ``B`` such that for all functions ``f`` annihilated by ``self``, ``A(f)(a(x)) = B(f(a(x)))``.
 
         EXAMPLES:
 

--- a/src/ore_algebra/ore_operator_1_1.py
+++ b/src/ore_algebra/ore_operator_1_1.py
@@ -1959,9 +1959,11 @@ class UnivariateDifferentialOperatorOverUnivariateRing(UnivariateOreOperatorOver
         """
         return self*self.parent().gen()
 
-        def change_of_variables(self,a, solver=None, onlyself=False):
+    def change_of_variables(self,a, solver=None, onlyself=False):
         r"""
-        Perform the change of variable x <- a(x) in ``self``.
+        Returns an operator ``L`` which annihilates all the functions `f(a(x))`
+        where `f` runs through the functions annihilated by ``self``, and a map
+        from the quotient by ``self`` to the quotient by `L` commuting with the composition by `a`.
 
         INPUT:
 
@@ -1969,7 +1971,7 @@ class UnivariateDifferentialOperatorOverUnivariateRing(UnivariateOreOperatorOver
           or an element of an algebraic extension of this ring.
         - ``solver`` (optional) -- a callable object which applied to a matrix
           with polynomial entries returns its kernel.
-        - ``onlyself`` (optional) -- if True, do not compute ``conv``
+        - ``onlyself`` (optional) -- if `True`, only compute the operator ``L``
 
         OUTPUT:
 
@@ -2007,7 +2009,7 @@ class UnivariateDifferentialOperatorOverUnivariateRing(UnivariateOreOperatorOver
             1/(2*x)*Dx
             sage: print(conv(x*Dx))
             ((x^2 + 1)/(2*x))*Dx
-        
+
         """
         
         A = self.parent(); K = A.base_ring().fraction_field(); A = A.change_ring(K); R = K['Y']

--- a/src/ore_algebra/ore_operator_1_1.py
+++ b/src/ore_algebra/ore_operator_1_1.py
@@ -1961,9 +1961,10 @@ class UnivariateDifferentialOperatorOverUnivariateRing(UnivariateOreOperatorOver
 
     def change_of_variables(self,a, solver=None, onlyself=False):
         r"""
-        Returns an operator ``L`` which annihilates all the functions `f(a(x))`
-        where `f` runs through the functions annihilated by ``self``, and a map
-        from the quotient by ``self`` to the quotient by `L` commuting with the composition by `a`.
+        Returns an operator `L` which annihilates all the functions `f(a(x))` where
+        `f` runs through the functions annihilated by ``self``, and a map from
+        the quotient by ``self`` to the quotient by `L` commuting with the
+        composition by `a`.
 
         INPUT:
 

--- a/src/ore_algebra/ore_operator_1_1.py
+++ b/src/ore_algebra/ore_operator_1_1.py
@@ -1980,7 +1980,7 @@ class UnivariateDifferentialOperatorOverUnivariateRing(UnivariateOreOperatorOver
         ``self``, ``L`` annihilates ``f \circ a``.
         - ``conv`` -- a function which takes as input an Ore operator ``A`` and
           returns an Ore operator ``B`` such that for all functions ``f``
-          annihilated by ``self``, ``A(f)(a(x)) = B(f(a(x)))``.
+          annihilated by ``self``, ``A(f)(a(x)) = B(f \circ a)(x)``.
 
         EXAMPLES:
 


### PR DESCRIPTION
This patch extends the method `annihilator_of_composition` in the differential case, to also compute a map between the corresponding quotients. 

I moved the extended code to a new method named `change_of_variables` (for the moment) and replaced `annihilator_of_composition` with a thin wrapper around it.

I am not sure if there is a way to compute such a map when composing with an algebraic function, so right now the method fails in that case.

In terms of interface, the map is returned as a callable function taking as input an element of the parent Ore algebra and returning another element of the parent Ore algebra. An optional parameter can specify that this map is not needed (the call in `annihilator_of_composition` sets it so that it doesn't fail when called with an algebraic function).

Some other choices for the interface could be:
- put everything in `annihilator_of_composition` and add an optional parameter specifying that such a map is to be computed and returned
- return the map as a more explicit object, such as the matrix used to define it; but calling the map would then become awkward, requiring to extract the coefficients of the input operator, compose them with the function, and multiply by the matrix.
