### PR TITLE
Evaluation of operators with rat coefficients on series

### DIFF
--- a/src/ore_algebra/generalized_series.py
+++ b/src/ore_algebra/generalized_series.py
@@ -70,7 +70,7 @@ class GeneralizedSeriesMonoid(UniqueRepresentation, Parent):
     """
 
     @staticmethod
-    def __classcall__(cls, base, x, type="continuous"):
+    def __classcall__(cls, base, x, type="continuous", default_prec=None):
         if not (any(base is P for P in [ZZ, QQ, QQbar])
                 or isinstance(base, NumberField)):
             raise TypeError("base ring must be ZZ, QQbar or a number field")
@@ -80,7 +80,7 @@ class GeneralizedSeriesMonoid(UniqueRepresentation, Parent):
         type = str(type)
         if type != "continuous" and type != "discrete":
             raise ValueError("type must be either \"continuous\" or \"discrete\"")
-        return super(GeneralizedSeriesMonoid, cls).__classcall__(cls, base, x, type)
+        return super(GeneralizedSeriesMonoid, cls).__classcall__(cls, base, x, type, default_prec=default_prec)
 
     def __init__(self, base, x, type, default_prec=None):
         r"""

--- a/src/ore_algebra/generalized_series.py
+++ b/src/ore_algebra/generalized_series.py
@@ -82,7 +82,7 @@ class GeneralizedSeriesMonoid(UniqueRepresentation, Parent):
             raise ValueError("type must be either \"continuous\" or \"discrete\"")
         return super(GeneralizedSeriesMonoid, cls).__classcall__(cls, base, x, type)
 
-    def __init__(self, base, x, type):
+    def __init__(self, base, x, type, default_prec=None):
         r"""
         Creates a monoid of generalized series objects.
 
@@ -91,9 +91,10 @@ class GeneralizedSeriesMonoid(UniqueRepresentation, Parent):
         - ``base`` -- constant field, may be either ``QQ`` or a number field.
         - ``x`` -- name of the variable, must not contain the substring ``"log"``.
         - ``type`` (optional) -- either ``"continuous"`` or ``"discrete"``.
+        - ``default_prec`` (optional) -- default precision to use for the underlying series ring
 
         If the type is ``"continuous"``, the domain contains series objects of the form
-
+p
         `\exp(\int_0^x \frac{p(t^{-1/r})}t dt)*q(x^{1/r},\log(x))`
 
         where
@@ -174,7 +175,7 @@ class GeneralizedSeriesMonoid(UniqueRepresentation, Parent):
         """
         self.__type = type
         self.__exp_ring = base[x]
-        self.__tail_ring = PowerSeriesRing(base, x)['LOG']
+        self.__tail_ring = PowerSeriesRing(base, x, default_prec=default_prec)['LOG']
         self.__var = x
         self.Element = (ContinuousGeneralizedSeries if self.is_continuous()
                         else DiscreteGeneralizedSeries)

--- a/src/ore_algebra/ore_operator.py
+++ b/src/ore_algebra/ore_operator.py
@@ -31,6 +31,8 @@ from sage.rings.laurent_series_ring import LaurentSeriesRing
 from sage.rings.laurent_series_ring_element import LaurentSeries
 from sage.functions.generalized import sign
 
+from .generalized_series import ContinuousGeneralizedSeries, GeneralizedSeriesMonoid
+
 class OreOperator(RingElement):
     """
     An Ore operator. This is an abstract class whose instances represent elements of ``OreAlgebra``.
@@ -644,10 +646,11 @@ class UnivariateOreOperator(OreOperator):
                     prec = None
                 R = f.parent()
                 R = LaurentSeriesRing(R.base_ring(), R.gen(), default_prec=prec)
-            elif isinstance(f,GeneralizedSeries):
+            elif isinstance(f,ContinuousGeneralizedSeries): 
                 prec = f.prec()
                 R = f.parent()
-                R = GeneralizedSeriesMonoid(R.base_ring(), R.gen(), R.__type, default_prec=prec)
+                R = GeneralizedSeriesMonoid(R.base_ring(), R.gen(),
+                                            "continuous", default_prec=prec)
             else:
                 R = f.parent()
                 

--- a/src/ore_algebra/ore_operator.py
+++ b/src/ore_algebra/ore_operator.py
@@ -26,6 +26,8 @@ from sage.arith.all import gcd, lcm
 from sage.rings.rational_field import QQ
 from sage.rings.integer_ring import ZZ
 from sage.rings.infinity import infinity
+from sage.rings.power_series_ring_element import PowerSeries
+from sage.rings.laurent_series_ring_element import LaurentSeries
 from sage.functions.generalized import sign
 
 class OreOperator(RingElement):
@@ -633,9 +635,18 @@ class UnivariateOreOperator(OreOperator):
 
         try:
             f, _ = canonical_coercion(f, self.base_ring().zero())
+            R = f.parent()
         except:
-            pass
-        R = f.parent()
+            if isinstance(f,PowerSeries) or isinstance(f,LaurentSeries):
+                from sage.rings.laurent_series_ring import LaurentSeriesRing
+                prec = f.precision_relative()
+                if prec is infinity:
+                    prec = None
+                R = f.parent()
+                R = LaurentSeriesRing(R.base_ring(), R.gen(), default_prec=prec)
+            else:
+                R = f.parent()
+                
         coeffs = self.coefficients(sparse=False)
         Dif = f; result = R(coeffs[0])*f; 
         for i in range(1, self.order() + 1):

--- a/src/ore_algebra/ore_operator.py
+++ b/src/ore_algebra/ore_operator.py
@@ -27,6 +27,7 @@ from sage.rings.rational_field import QQ
 from sage.rings.integer_ring import ZZ
 from sage.rings.infinity import infinity
 from sage.rings.power_series_ring_element import PowerSeries
+from sage.rings.laurent_series_ring import LaurentSeriesRing
 from sage.rings.laurent_series_ring_element import LaurentSeries
 from sage.functions.generalized import sign
 
@@ -638,7 +639,6 @@ class UnivariateOreOperator(OreOperator):
             R = f.parent()
         except:
             if isinstance(f,PowerSeries) or isinstance(f,LaurentSeries):
-                from sage.rings.laurent_series_ring import LaurentSeriesRing
                 prec = f.precision_relative()
                 if prec is infinity:
                     prec = None

--- a/src/ore_algebra/ore_operator.py
+++ b/src/ore_algebra/ore_operator.py
@@ -644,6 +644,10 @@ class UnivariateOreOperator(OreOperator):
                     prec = None
                 R = f.parent()
                 R = LaurentSeriesRing(R.base_ring(), R.gen(), default_prec=prec)
+            elif isinstance(f,GeneralizedSeries):
+                prec = f.prec()
+                R = f.parent()
+                R = GeneralizedSeriesMonoid(R.base_ring(), R.gen(), R.__type, default_prec=prec)
             else:
                 R = f.parent()
                 


### PR DESCRIPTION
This is an attempt at fixing two bugs when evaluating differential operators on power or Laurent series.

The first bug concerns the precision of the output, which should be limited by the precision of the input series when the operator has exact coefficients, and not by the default precision of the parent ring of the series:

```
sage: from ore_algebra import *
sage: Pol.<x> = PolynomialRing(QQ)
sage: Frac = Pol.fraction_field()
sage: Dif.<Dx> = OreAlgebra(Pol)
sage: Dif = Dif.change_ring(Frac)
sage: L = (1/(1-x))*Dx
sage: Pow.<x> = PowerSeriesRing(QQ,default_prec=5)
sage: Laur = Pow.fraction_field()
sage: f = Laur(x + O(x^20));f
x + O(x^20)
sage: L(f)
x^-1 + O(x^18)
sage: L(f.add_bigoh(10))
x^-1 + O(x^8)
```

Without the patch, the output would be `x^-1 + O(x^4)` in both cases.

The second bug is that the package was not able to evaluate a differential operator on a power series if the output is a Laurent series.

```
sage: f = Pow(x); f
x
sage: L(f)
x^-1
sage: f = Pow(1/(1+x)); f
1 - x + x^2 - x^3 + x^4 + O(x^5)
sage: L(f)
-x^-1 + 2 - 3*x + 4*x^2 + O(x^3)
```

Without the patch, both evaluations would fail.

The patch is a bit clumsy, there is probably a cleaner way to achieve the same result.