### PR TITLE
Bugfix: workaround for no change_ring for rational function fields

### DIFF
--- a/src/ore_algebra/ore_operator_1_1.py
+++ b/src/ore_algebra/ore_operator_1_1.py
@@ -3415,15 +3415,25 @@ class UnivariateDifferentialOperatorOverUnivariateRing(UnivariateOreOperatorOver
 
         r = self.order()
         ore = self.parent()
-        x = ore.base_ring().gen()
-        C = ore.base_ring().base_ring()
+
+        base = ore.base_ring()
+
+        x = base.gen()
+        C = base.base_ring()
         if f.degree() > 1:
             FF = NumberField(f,"xi")
             xi = FF.gen()
         else:
             FF = C
             xi = -f[0]/f[1]
-        ore_ext = ore.change_ring(ore.base_ring().change_ring(FF).fraction_field())
+
+        # Next lines because there is no change_ring() method for a fraction
+        # field, so we need to proceed in two steps.
+        if base.is_field():
+            base = base.ring()
+        pol_ext = base.change_ring(FF)
+        ore_ext = ore.change_ring(pol_ext.fraction_field())
+        
         reloc = ore_ext([c(x=x+xi) for c in self.coefficients(sparse=False)])
         if prec is None:
             sols = reloc.generalized_series_solutions(exp=False)


### PR DESCRIPTION
Hi,

The current methods for evaluating the valuation of differential operators can fail if the coefficient ring of the Ore algebra is a fraction field.

```
sage: from ore_algebra import *
sage: import pdb
sage: Pol.<x> = PolynomialRing(QQ)
sage: Dif.<Dx> = OreAlgebra(Pol)
sage: Dif = Dif.change_ring(Pol.fraction_field())
sage: Dx = Dif.gen()
sage: L = x*Dx^2 + 1
sage: q = x*Dx
sage: L.value_function(x*Dx,x-1)
Traceback (most recent call last):
...
AttributeError: 'FractionField_1poly_field_with_category' object has no attribute 'change_ring'
```

This patch should fix it.