### PR TITLE
fix comparison to None

### DIFF
--- a/src/ore_algebra/dfinite_function.py
+++ b/src/ore_algebra/dfinite_function.py
@@ -930,7 +930,7 @@ class DFiniteFunction(RingElement):
             
             #if the initial values contain symbolic expressions we can't use guessing - but we can
             #try to get rid of multiple common factors in the coefficients and redundant initial conditions
-            elif not all(x in QQ for x in ini.values() if x != None):
+            elif not all(x in QQ for x in ini.values() if x is not None):
                 return self.reduce_factors()
             
             #if all initial conditions are in QQ we can try to guess a smaller operator
@@ -2125,7 +2125,7 @@ class UnivariateDFiniteSequence(DFiniteFunction):
             singularities_negative = set([i for i in sum_ann.singularities(True) if i < 0])
     
         initial_val = set(range(ord)).union(singularities_positive, singularities_negative)
-        int_val_sum = {n:self[n] + right[n] if (self[n] != None and right[n] != None) else None for n in initial_val}
+        int_val_sum = {n:self[n] + right[n] if (self[n] is not None and right[n] is not None) else None for n in initial_val}
 
         #critical points for forward calculation
         critical_points_positive = self.critical_points(ord).union( right.critical_points(ord) )
@@ -2133,10 +2133,10 @@ class UnivariateDFiniteSequence(DFiniteFunction):
             critical_points_positive.update(range(n+1,n+ord+1))
         
         for n in critical_points_positive:
-            int_val_sum.update({n:self[n] + right[n] if (self[n] != None and right[n] != None) else None})
+            int_val_sum.update({n:self[n] + right[n] if (self[n] is not None and right[n] is not None) else None})
             sum_ann = A(N - (n - ord) )*sum_ann
             if self.parent()._backward_calculation is True and n < ord - min_degree:
-                int_val_sum.update({(n-ord)+min_degree: self[(n-ord)+min_degree] + right[(n-ord)+min_degree] if (self[(n-ord)+min_degree] != None and right[(n-ord)+min_degree] != None) else None})
+                int_val_sum.update({(n-ord)+min_degree: self[(n-ord)+min_degree] + right[(n-ord)+min_degree] if (self[(n-ord)+min_degree] is not None and right[(n-ord)+min_degree] is not None) else None})
         
         #critical points for backward calculation
         critical_points_negative = self.critical_points(ord,True).union( right.critical_points(ord,True) )
@@ -2144,10 +2144,10 @@ class UnivariateDFiniteSequence(DFiniteFunction):
             critical_points_negative.update(range(n-ord,n))
             
         for n in critical_points_negative:
-            int_val_sum.update({n:self[n] + right[n] if (self[n] != None and right[n] != None) else None})
+            int_val_sum.update({n:self[n] + right[n] if (self[n] is not None and right[n] is not None) else None})
             sum_ann = A(N - (n - min_degree) )*sum_ann
             if n >= min_degree:
-                int_val_sum.update({(n-min_degree)+ord:self[(n-min_degree)+ord] + right[(n-min_degree)+ord] if (self[(n-min_degree)+ord] != None and right[(n-min_degree)+ord] != None) else None})
+                int_val_sum.update({(n-min_degree)+ord:self[(n-min_degree)+ord] + right[(n-min_degree)+ord] if (self[(n-min_degree)+ord] is not None and right[(n-min_degree)+ord] is not None) else None})
         
         sum = UnivariateDFiniteSequence(self.parent(), sum_ann, int_val_sum)
 
@@ -2170,7 +2170,7 @@ class UnivariateDFiniteSequence(DFiniteFunction):
             [0, -1, -2, -3, -4, -5, -6, -7, -8, -9, -10]
 
         """
-        neg_int_val = {key:(-self._initial_values[key]) if (self._initial_values[key] != None) else None for key in self._initial_values}
+        neg_int_val = {key:(-self._initial_values[key]) if (self._initial_values[key] is not None) else None for key in self._initial_values}
         return UnivariateDFiniteSequence(self.parent(), self.ann(), neg_int_val)
 
     def _mul_(self, right):
@@ -2214,7 +2214,7 @@ class UnivariateDFiniteSequence(DFiniteFunction):
             singularities_negative = set([i for i in prod_ann.singularities(True) if i < 0])
     
         initial_val = set(range(ord)).union(singularities_positive, singularities_negative)
-        int_val_prod = {n:self[n] * right[n] if (self[n] != None and right[n] != None) else None for n in initial_val }
+        int_val_prod = {n:self[n] * right[n] if (self[n] is not None and right[n] is not None) else None for n in initial_val }
         
         #critical points for forward calculation
         critical_points_positive = self.critical_points(ord).union( right.critical_points(ord) )
@@ -2222,10 +2222,10 @@ class UnivariateDFiniteSequence(DFiniteFunction):
             critical_points_positive.update(range(n+1,n+ord+1))
         
         for n in critical_points_positive:
-            int_val_prod.update({n:self[n] * right[n] if (self[n] != None and right[n] != None) else None})
+            int_val_prod.update({n:self[n] * right[n] if (self[n] is not None and right[n] is not None) else None})
             prod_ann = A(N - (n - ord) )*prod_ann
             if self.parent()._backward_calculation is True and n < ord - min_degree:
-                int_val_prod.update({(n-ord)+min_degree: self[(n-ord)+min_degree] * right[(n-ord)+min_degree] if (self[(n-ord)+min_degree] != None and right[(n-ord)+min_degree] != None) else None})
+                int_val_prod.update({(n-ord)+min_degree: self[(n-ord)+min_degree] * right[(n-ord)+min_degree] if (self[(n-ord)+min_degree] is not None and right[(n-ord)+min_degree] is not None) else None})
         
         #critical points for backward calculation
         critical_points_negative = self.critical_points(ord,True).union( right.critical_points(ord,True) )
@@ -2233,10 +2233,10 @@ class UnivariateDFiniteSequence(DFiniteFunction):
             critical_points_negative.update(range(n-ord,n))
         
         for n in critical_points_negative:
-            int_val_prod.update({n:self[n] * right[n] if (self[n] != None and right[n] != None) else None})
+            int_val_prod.update({n:self[n] * right[n] if (self[n] is not None and right[n] is not None) else None})
             prod_ann = A(N-(n-min_degree))*prod_ann
             if n >= min_degree:
-                int_val_prod.update({(n-min_degree)+ord:self[(n-min_degree)+ord] * right[(n-min_degree)+ord] if (self[(n-min_degree)+ord] != None and right[(n-min_degree)+ord] != None) else None})
+                int_val_prod.update({(n-min_degree)+ord:self[(n-min_degree)+ord] * right[(n-min_degree)+ord] if (self[(n-min_degree)+ord] is not None and right[(n-min_degree)+ord] is not None) else None})
         
         prod = UnivariateDFiniteSequence(self.parent(), prod_ann, int_val_prod)
         return prod
@@ -2297,7 +2297,7 @@ class UnivariateDFiniteSequence(DFiniteFunction):
             a = self.expand(n)
             b = right.expand(n)
             b.reverse()
-            if all(x != None for x in a) and all(y != None for y in b):
+            if all(x is not None for x in a) and all(y is not None for y in b):
                 cauchy = sum([x*y for x,y in zip(a,b)])
             else:
                 cauchy = None
@@ -2312,7 +2312,7 @@ class UnivariateDFiniteSequence(DFiniteFunction):
             a = self.expand(n)
             b = right.expand(n)
             b.reverse()
-            if all(x != None for x in a) and all(y != None for y in b):
+            if all(x is not None for x in a) and all(y is not None for y in b):
                 cauchy = sum([x*y for x,y in zip(a,b)])
             else:
                 cauchy = None
@@ -2322,7 +2322,7 @@ class UnivariateDFiniteSequence(DFiniteFunction):
                 a = self.expand((n-ord)+min_degree)
                 b = right.expand((n-ord)+min_degree)
                 b.reverse()
-                if all(x != None for x in a) and all(y != None for y in b):
+                if all(x is not None for x in a) and all(y is not None for y in b):
                     cauchy = sum([x*y for x,y in zip(a,b)])
                 else:
                     cauchy = None
@@ -2338,7 +2338,7 @@ class UnivariateDFiniteSequence(DFiniteFunction):
             a = self.expand(n)
             b = right.expand(n)
             b.reverse()
-            if all(x != None for x in a) and all(y != None for y in b):
+            if all(x is not None for x in a) and all(y is not None for y in b):
                 cauchy = sum([x*y for x,y in zip(a,b)])
             else:
                 cauchy = None
@@ -2348,7 +2348,7 @@ class UnivariateDFiniteSequence(DFiniteFunction):
                 a = self.expand((n-min_degree)+ord)
                 b = right.expand((n-min_degree)+ord)
                 b.reverse()
-                if all(x != None for x in a) and all(y != None for y in b):
+                if all(x is not None for x in a) and all(y is not None for y in b):
                     cauchy = sum([x*y for x,y in zip(a,b)])
                 else:
                     cauchy = None
@@ -2491,7 +2491,7 @@ class UnivariateDFiniteSequence(DFiniteFunction):
             singularities_negative = set([i for i in sum_ann.singularities(True) if i < 0])
     
         initial_val = set(range(ord)).union(singularities_positive, singularities_negative)
-        int_val_sum = {n : sum(self.expand(n)) if all(self[k] != None for k in range(n+1)) else None for n in initial_val}
+        int_val_sum = {n : sum(self.expand(n)) if all(self[k] is not None for k in range(n+1)) else None for n in initial_val}
 
         #critical points for forward calculation
         critical_points_positive = self.critical_points(ord)
@@ -2499,10 +2499,10 @@ class UnivariateDFiniteSequence(DFiniteFunction):
             critical_points_positive.update(range(n+1,n+ord+1))
     
         for n in critical_points_positive:
-            int_val_sum.update({n : sum(self.expand(n)) if all(self[k] != None for k in range(n+1)) else None})
+            int_val_sum.update({n : sum(self.expand(n)) if all(self[k] is not None for k in range(n+1)) else None})
             sum_ann = A(N - (n - ord) )*sum_ann
             if self.parent()._backward_calculation is True and n < ord - min_degree:
-                int_val_sum.update({(n-ord)+min_degree : sum(self.expand((n-ord)+min_degree)) if all(self[k] != None for k in range((n-ord)+min_degree+1)) else None})
+                int_val_sum.update({(n-ord)+min_degree : sum(self.expand((n-ord)+min_degree)) if all(self[k] is not None for k in range((n-ord)+min_degree+1)) else None})
         
         #critical points for backward calculation
         critical_points_negative = self.critical_points(ord,True)
@@ -2510,10 +2510,10 @@ class UnivariateDFiniteSequence(DFiniteFunction):
             critical_points_negative.update(range(n-ord,n))
             
         for n in critical_points_negative:
-            int_val_sum.update({n : sum(self.expand(n)) if all(self[k] != None for k in range(n+1)) else None})
+            int_val_sum.update({n : sum(self.expand(n)) if all(self[k] is not None for k in range(n+1)) else None})
             sum_ann = A(N - (n - min_degree) )*sum_ann
             if n >= min_degree:
-                int_val_sum.update({(n-min_degree)+ord : sum(self.expand((n-min_degree)+ord)) if all(self[k] != None for k in range((n-min_degree)+ord+1)) else None})
+                int_val_sum.update({(n-min_degree)+ord : sum(self.expand((n-min_degree)+ord)) if all(self[k] is not None for k in range((n-min_degree)+ord+1)) else None})
 
         return UnivariateDFiniteSequence(self.parent(), sum_ann, int_val_sum)
     
@@ -2891,7 +2891,7 @@ class UnivariateDFiniteFunction(DFiniteFunction):
             coeffs_result[i] = result[i].rhs()
         poly = sum(list(a*b for a,b in zip(coeffs_result,base)))
         
-        if all(poly.derivative(k)(x=0)/factorial(k) == self[k] for k in self.initial_conditions().initial_conditions() if (self[k] != None and k>=0)):
+        if all(poly.derivative(k)(x=0)/factorial(k) == self[k] for k in self.initial_conditions().initial_conditions() if (self[k] is not None and k>=0)):
             return R(poly)
         else:
             raise TypeError("the D-finite function is not a polynomial")
@@ -2957,7 +2957,7 @@ class UnivariateDFiniteFunction(DFiniteFunction):
         coeffs_result = list( result[i].rhs() for i in range(len(result)) )
         result = sum(list(a*b for a,b in zip(coeffs_result,base)))
 
-        if all(result.derivative(k)(x=0)/factorial(k) == self[k] for k in self.initial_conditions().initial_conditions() if (self[k] != None and k >= 0)):
+        if all(result.derivative(k)(x=0)/factorial(k) == self[k] for k in self.initial_conditions().initial_conditions() if (self[k] is not None and k >= 0)):
             return R.fraction_field()(result)
         else:
             raise TypeError("the D-finite function is not a rational function")

--- a/src/ore_algebra/nullspace.py
+++ b/src/ore_algebra/nullspace.py
@@ -441,11 +441,11 @@ def _alter_infolevel(infolevel, dlevel, dprefix):
 def _launch_info(infolevel, name, dim=None, deg=None, domain=None):
     def make_message():
         message = datetime.today().ctime() + ": " + name + " called";
-        if not dim == None:
+        if dim is not None:
             message = message + ", dim=" + str(dim)
-        if not deg == None:
+        if deg is not None:
             message = message + ", deg=" + str(deg)
-        if not domain == None:
+        if domain is not None:
             try:
                 message = message + ", domain=" + domain._latex_()
             except:
@@ -1372,7 +1372,7 @@ def _cra(subsolver, max_modulus, proof, ncpus, mat, degrees, infolevel):
         if len(degrees) != len(x):
             degrees = [-1 for i in x]
         
-        if V == None or len(V) > len(Vp) or any(degrees[i] > true_degrees[i] for i in range(len(x))):
+        if V is None or len(V) > len(Vp) or any(degrees[i] > true_degrees[i] for i in range(len(x))):
             # initialization, or all previous primes were unlucky
             if len(Vp) == 0:
                 return []

--- a/src/ore_algebra/ore_operator.py
+++ b/src/ore_algebra/ore_operator.py
@@ -1183,7 +1183,7 @@ class UnivariateOreOperator(OreOperator):
             rowsB.append(D*rowsB[-1])
 
         from sage.matrix.constructor import Matrix
-        if solver == None:
+        if solver is None:
             solver = A.parent()._solver()
 
         sys = Matrix(list(map(lambda p: p.coefficients(sparse=False,padd=t), rowsA + rowsB))).transpose()
@@ -1335,7 +1335,7 @@ class UnivariateOreOperator(OreOperator):
 
         # for better performance, we don't use the sylvester matrix 
         for i in range(m):
-            A = self if A == None else D*A
+            A = self if A is None else D*A
             mat.append((A % other).coefficients(sparse=False,padd=m-1))
 
         from sage.matrix.constructor import matrix      
@@ -1583,7 +1583,7 @@ class UnivariateOreOperator(OreOperator):
         B = other.change_ring(R) % A
         D = A.parent().gen()
 
-        if solver == None:
+        if solver is None:
             solver = A.parent()._solver()
 
         mat = [B.coefficients(sparse=False,padd=a-1)]
@@ -1841,7 +1841,7 @@ class UnivariateOreOperator(OreOperator):
         coefficients of self.
         """
         poly = self.polynomial().map_coefficients(f, new_base_ring = new_base_ring)
-        if new_base_ring == None:
+        if new_base_ring is None:
             return self.parent()(poly)
         else:
             return self.parent().base_extend(new_base_ring)(poly)

--- a/src/ore_algebra/ore_operator_1_1.py
+++ b/src/ore_algebra/ore_operator_1_1.py
@@ -2211,7 +2211,7 @@ class UnivariateDifferentialOperatorOverUnivariateRing(UnivariateOreOperatorOver
         """
         
         A = self.parent(); K = A.base_ring().fraction_field(); A = A.change_ring(K); R = K['Y']
-        if solver == None:
+        if solver is None:
             solver = A._solver(K)
 
         if self == A.one() or a == K.gen():
@@ -4139,7 +4139,7 @@ class UnivariateRecurrenceOperatorOverUnivariateRing(UnivariateOreOperatorOverUn
         u = u.numerator()
         from sage.matrix.constructor import Matrix
         A = A.change_ring(A.base_ring().fraction_field())
-        if solver == None:
+        if solver is None:
             solver = A._solver()
         L = A(self)
 
@@ -5028,7 +5028,7 @@ class UnivariateQRecurrenceOperatorOverUnivariateRing(UnivariateOreOperatorOverU
 
         # now a = u*x where u > 1 
         from sage.matrix.constructor import Matrix
-        if solver == None:
+        if solver is None:
             solver = A._solver()
 
         p = A.one(); Qu = A.gen()**u # possible improvement: multiplication matrix. 


### PR DESCRIPTION
which is pycodestyle E7111.

Other warnings from pycodestyle are

```
3       E111 indentation is not a multiple of four
2       E114 indentation is not a multiple of four (comment)
1       E115 expected an indented block (comment)
7       E116 unexpected indentation (comment)
7       E117 over-indented
6       E121 continuation line under-indented for hanging indent
89      E122 continuation line missing indentation or outdented
3       E124 closing bracket does not match visual indentation
1       E125 continuation line with same indent as next logical line
62      E126 continuation line over-indented for hanging indent
121     E127 continuation line over-indented for visual indent
2082    E128 continuation line under-indented for visual indent
7       E131 continuation line unaligned for hanging indent
277     E201 whitespace after '('
292     E202 whitespace before ')'
48      E203 whitespace before ':'
2       E211 whitespace before '('
14      E221 multiple spaces before operator
10      E222 multiple spaces after operator
435     E225 missing whitespace around operator
19237   E226 missing whitespace around arithmetic operator
4       E227 missing whitespace around bitwise or shift operator
12      E228 missing whitespace around modulo operator
748     E231 missing whitespace after ','
4       E241 multiple spaces after ','
178     E251 unexpected spaces around keyword / parameter equals
331     E261 at least two spaces before inline comment
50      E262 inline comment should start with '# '
203     E265 block comment should start with '# '
27      E266 too many leading '#' for block comment
1       E271 multiple spaces after keyword
6       E301 expected 1 blank line, found 0
276     E302 expected 2 blank lines, found 1
29      E303 too many blank lines (2)
18      E305 expected 2 blank lines after class or function definition, found 1
53      E306 expected 1 blank line before a nested definition, found 0
8       E401 multiple imports on one line
63      E402 module level import not at top of file
27      E502 the backslash is redundant between brackets
20      E701 multiple statements on one line (colon)
450     E702 multiple statements on one line (semicolon)
55      E703 statement ends with a semicolon
1       E712 comparison to False should be 'if cond is False:' or 'if not cond:'
13      E713 test for membership should be 'not in'
76      E722 do not use bare 'except'
22      E731 do not assign a lambda expression, use a def
1120    W291 trailing whitespace
894     W293 blank line contains whitespace
7       W391 blank line at end of file

```