### PR TITLE
catching more specific exceptions

### DIFF
--- a/src/ore_algebra/guessing.py
+++ b/src/ore_algebra/guessing.py
@@ -1180,7 +1180,7 @@ def _ff_factory(domain):
     characteristic = domain.characteristic() # that's the only information that matters here
     try:
         return _ff_cache[characteristic]
-    except:
+    except KeyError:
         characteristic = int(characteristic)
         c = dict()
         if characteristic == 0:
@@ -1188,7 +1188,7 @@ def _ff_factory(domain):
             def ff(u, v): ## computation in ZZ; first argument must be integer too!
                 try:
                     return c[u, v]
-                except:
+                except KeyError:
                     if v == 0:
                         return one
                     else:
@@ -1199,7 +1199,7 @@ def _ff_factory(domain):
             def ff(u, v): ## computations with Python integers
                 try:
                     return c[u, v]
-                except:
+                except KeyError:
                     if v == 0:
                         return 1
                     else:
@@ -1216,7 +1216,7 @@ _power_cache = dict()
 def _power_factory(domain):
     try:
         return _power_cache[domain]
-    except:
+    except KeyError:
         c = dict()
         domain = domain.fraction_field()
         if domain.characteristic() > 0:
@@ -1224,7 +1224,7 @@ def _power_factory(domain):
             def power(u, v): # using Python integers
                 try:
                     return c[u, v]
-                except:
+                except KeyError:
                     if v == 0:
                         return 1
                     elif v < 0:
@@ -1316,6 +1316,7 @@ def guess_mult(data, algebra, **kwargs):
     """
 
     infolevel = kwargs.setdefault('infolevel', 0)
+
     def info(bound, msg):
         if bound <= infolevel:
             print(msg)
@@ -1554,6 +1555,7 @@ def guess_mult_raw(C, data, terms, points, power, A, B, **kwargs):
     """
 
     infolevel = kwargs.setdefault('infolevel', 0)
+
     def info(bound, msg):
         if bound <= infolevel:
             print(msg)

--- a/src/ore_algebra/ideal.py
+++ b/src/ore_algebra/ideal.py
@@ -1017,7 +1017,7 @@ class MonomialIterator(object):
         """
         try:
             u, v = self.__pool.pop()
-        except:
+        except IndexError:
             raise StopIteration
         self.__prev = next = u*v
         for g in self.__gens:

--- a/src/ore_algebra/nullspace.py
+++ b/src/ore_algebra/nullspace.py
@@ -378,7 +378,7 @@ def _pivot(mat, r, n, c, m, zero):
 def _leading_coefficient(p):
     try:
         return p.leading_coefficient() ## good for univariate polynomials
-    except:
+    except AttributeError:
         return p.lc() ## good for multivariate polynomials
 
 def _normalize(sol):

--- a/src/ore_algebra/tools.py
+++ b/src/ore_algebra/tools.py
@@ -189,7 +189,7 @@ def shift_factor(p, ram=ZZ.one(), q=1):
             d = u.degree()
             try:
                 return -q_log(qq, (u[d]/v[d])**ram)/d
-            except:
+            except ValueError:
                 return None
 
     for (q, b) in make_factor_iterator(p.parent())(p):


### PR DESCRIPTION
It is considered bad code quality to use `except:` because it catches all exceptions.

I tried to fix some of these.

I hope that I have chosen the correct exception to catch. Please check before merging.