### PR TITLE
Methods to change the constant ring of an algebra/operator

### DIFF
--- a/src/ore_algebra/ore_algebra.py
+++ b/src/ore_algebra/ore_algebra.py
@@ -301,6 +301,9 @@ class Sigma_class(object):
         """
         return self.__R
 
+    def change_ring(self, R):
+        return Sigma_class(R, self.dict())
+    
     def factorial(self, p, n):
         r"""
         Returns `p\sigma(p)...\sigma^{n-1}(p)` if `n` is nonnegative,
@@ -577,6 +580,9 @@ class Delta_class(object):
         """
         return self.__R
 
+    def change_ring(self, R):
+        return Delta_class(R, self.dict(), self.__sigma.change_ring(R))
+    
     def dict(self):
         r"""
         Returns a dictionary representing ``self``
@@ -1806,11 +1812,11 @@ class OreAlgebra_generic(UniqueRepresentation, Algebra):
         EXAMPLES:
 
           sage: from ore_algebra import *
-          sage: R.<x> = PolynomialRing(ZZ)
+          sage: R.<x> = PolynomialRing(QQ)
           sage: Ore.<Dx> = OreAlgebra(R)
           sage: S = R.fraction_field()
           sage: Ore.change_ring(S)
-          Univariate Ore algebra in Dx over Fraction Field of Univariate Polynomial Ring in x over Integer Ring
+          Univariate Ore algebra in Dx over Fraction Field of Univariate Polynomial Ring in x over Rational Field
           sage: T = R.change_ring(GF(5))
           sage: Ore.change_ring(T)
           Univariate Ore algebra in Dx over Univariate Polynomial Ring in x over Finite Field of size 5
@@ -1824,7 +1830,7 @@ class OreAlgebra_generic(UniqueRepresentation, Algebra):
         if R is self.base_ring():
             return self
         else:
-            return OreAlgebra(R, *self._gens)
+            return OreAlgebra(R, *((v, s.change_ring(R), d.change_ring(R)) for (v,s,d) in self._gens))
 
     def change_constant_ring(self, K):
         r"""
@@ -1833,7 +1839,7 @@ class OreAlgebra_generic(UniqueRepresentation, Algebra):
         EXAMPLES::
 
           sage: from ore_algebra import *
-          sage: R.<x> = PolynomialRing(ZZ)
+          sage: R.<x> = PolynomialRing(QQ)
           sage: Ore.<Dx> = OreAlgebra(R)
           sage: Ore.change_constant_ring(GF(5))
           Univariate Ore algebra in Dx over Univariate Polynomial Ring in x over Finite Field of size 5

--- a/src/ore_algebra/ore_algebra.py
+++ b/src/ore_algebra/ore_algebra.py
@@ -1815,6 +1815,19 @@ class OreAlgebra_generic(UniqueRepresentation, Algebra):
             self.__alternate_base_rings[R] = A
             return A
 
+    def change_constant_ring(self, K):
+        r"""
+        Creates the Ore algebra obtained from ``self`` by replacing the constant ring by `K`"""
+        R = self.base_ring()
+        if K is R.base_ring():
+            return self
+        elif R.is_field():
+            S = R.ring().change_ring(K).fraction_field()
+            return self.change_ring(S)
+        else:
+            S = R.change_ring(K)
+            return self.change_ring(S)
+
     def change_var(self, var, n=0):
         r"""
         Creates the Ore algebra obtained from ``self`` by renaming the `n` th generator to `var`

--- a/src/ore_algebra/ore_algebra.py
+++ b/src/ore_algebra/ore_algebra.py
@@ -1806,11 +1806,11 @@ class OreAlgebra_generic(UniqueRepresentation, Algebra):
         EXAMPLES:
 
           sage: from ore_algebra import *
-          sage: R.<x> = PolynomialRing(QQ)
+          sage: R.<x> = PolynomialRing(ZZ)
           sage: Ore.<Dx> = OreAlgebra(R)
           sage: S = R.fraction_field()
           sage: Ore.change_ring(S)
-          Univariate Ore algebra in Dx over Fraction Field of Univariate Polynomial Ring in x over Rational Field
+          Univariate Ore algebra in Dx over Fraction Field of Univariate Polynomial Ring in x over Integer Ring
           sage: T = R.change_ring(GF(5))
           sage: Ore.change_ring(T)
           Univariate Ore algebra in Dx over Univariate Polynomial Ring in x over Finite Field of size 5
@@ -1824,7 +1824,7 @@ class OreAlgebra_generic(UniqueRepresentation, Algebra):
         if R is self.base_ring():
             return self
         else:
-            return OreAlgebra(R, *self.variable_names())
+            return OreAlgebra(R, *self._gens)
 
     def change_constant_ring(self, K):
         r"""
@@ -1833,7 +1833,7 @@ class OreAlgebra_generic(UniqueRepresentation, Algebra):
         EXAMPLES::
 
           sage: from ore_algebra import *
-          sage: R.<x> = PolynomialRing(QQ)
+          sage: R.<x> = PolynomialRing(ZZ)
           sage: Ore.<Dx> = OreAlgebra(R)
           sage: Ore.change_constant_ring(GF(5))
           Univariate Ore algebra in Dx over Univariate Polynomial Ring in x over Finite Field of size 5

--- a/src/ore_algebra/ore_algebra.py
+++ b/src/ore_algebra/ore_algebra.py
@@ -1798,6 +1798,7 @@ class OreAlgebra_generic(UniqueRepresentation, Algebra):
                             if old[i][j] != new[i][j]:
                                 raise ValueError("inconsistent product rule specification")
 
+    @cached_method
     def change_ring(self, R):
         r"""
         Creates the Ore algebra obtained from ``self`` by replacing the base ring by `R`
@@ -1823,15 +1824,7 @@ class OreAlgebra_generic(UniqueRepresentation, Algebra):
         if R is self.base_ring():
             return self
         else:
-            try:
-                return self.__alternate_base_rings[R]
-            except AttributeError:
-                self.__alternate_base_rings = {}
-            except KeyError:
-                pass
-            A = OreAlgebra(R, *self.variable_names())
-            self.__alternate_base_rings[R] = A
-            return A
+            return OreAlgebra(R, *self.variable_names())
 
     def change_constant_ring(self, K):
         r"""

--- a/src/ore_algebra/ore_algebra.py
+++ b/src/ore_algebra/ore_algebra.py
@@ -1811,7 +1811,7 @@ class OreAlgebra_generic(UniqueRepresentation, Algebra):
                 self.__alternate_base_rings = {}
             except KeyError:
                 pass
-            A = OreAlgebra(R, *self._gens)
+            A = OreAlgebra(R, *self.variable_names())
             self.__alternate_base_rings[R] = A
             return A
 

--- a/src/ore_algebra/ore_algebra.py
+++ b/src/ore_algebra/ore_algebra.py
@@ -1801,6 +1801,24 @@ class OreAlgebra_generic(UniqueRepresentation, Algebra):
     def change_ring(self, R):
         r"""
         Creates the Ore algebra obtained from ``self`` by replacing the base ring by `R`
+
+        EXAMPLES:
+
+          sage: from ore_algebra import *
+          sage: R.<x> = PolynomialRing(QQ)
+          sage: Ore.<Dx> = OreAlgebra(R)
+          sage: S = R.fraction_field()
+          sage: Ore.change_ring(S)
+          Univariate Ore algebra in Dx over Fraction Field of Univariate Polynomial Ring in x over Rational Field
+          sage: T = R.change_ring(GF(5))
+          sage: Ore.change_ring(T)
+          Univariate Ore algebra in Dx over Univariate Polynomial Ring in x over Finite Field of size 5
+
+        Identical inputs yield the same ring.
+
+          sage: Ore.change_ring(R.fraction_field()) is Ore.change_ring(R.fraction_field())
+          True
+        
         """
         if R is self.base_ring():
             return self
@@ -1817,7 +1835,25 @@ class OreAlgebra_generic(UniqueRepresentation, Algebra):
 
     def change_constant_ring(self, K):
         r"""
-        Creates the Ore algebra obtained from ``self`` by replacing the constant ring by `K`"""
+        Creates the Ore algebra obtained from ``self`` by replacing the constant ring by `K`
+
+        EXAMPLES::
+
+          sage: from ore_algebra import *
+          sage: R.<x> = PolynomialRing(QQ)
+          sage: Ore.<Dx> = OreAlgebra(R)
+          sage: Ore.change_constant_ring(GF(5))
+          Univariate Ore algebra in Dx over Univariate Polynomial Ring in x over Finite Field of size 5
+          sage: Ore2.<Dx> = OreAlgebra(R.fraction_field())
+          sage: Ore2.change_constant_ring(GF(5))
+          Univariate Ore algebra in Dx over Fraction Field of Univariate Polynomial Ring in x over Finite Field of size 5
+
+        Identical inputs yield the same ring.
+
+          sage: Ore.change_constant_ring(GF(5)) is Ore.change_constant_ring(ZZ.quo(5).field())
+          True
+        
+        """
         R = self.base_ring()
         if K is R.base_ring():
             return self

--- a/src/ore_algebra/ore_operator.py
+++ b/src/ore_algebra/ore_operator.py
@@ -199,15 +199,14 @@ class OreOperator(RingElement):
           sage: R.<x,y> = PolynomialRing(QQ)
           sage: A.<Dx,Dy> = OreAlgebra(R)
           sage: op = (x+6)*Dx^2 + 1/2*Dx*Dy
-          sage: _ = var('t')
-          sage: K.<a> = NumberField(t^2-2)
-          sage: op2 = op.change_constant_ring(K)
+          sage: op2 = op.change_constant_ring(GF(5)); op2
+          (x + 1)*Dx^2 + (-2)*Dx*Dy
           sage: op2.parent()
-          Multivariate Ore algebra in Dx, Dy over Multivariate Polynomial Ring in x, y over Number Field in a with defining polynomial t^2 - 2
-          sage: op = (1/x)*((x+6)*Dx^2 + 1/2*Dx*Dy)
-          sage: op2 = op.change_constant_ring(K)
+          Multivariate Ore algebra in Dx, Dy over Multivariate Polynomial Ring in x, y over Finite Field of size 5
+          sage: op = (1/x)*((x+6)*Dx^2 + 1/2*Dx*Dy); op2
+          sage: op2 = op.change_constant_ring(GF(5))
           sage: op2.parent()
-          Multivariate Ore algebra in Dx, Dy over Fraction Field of Multivariate Polynomial Ring in x, y over Number Field in a with defining polynomial t^2 - 2
+          Multivariate Ore algebra in Dx, Dy over Fraction Field of Multivariate Polynomial Ring in x, y over Finite Field of size 5
           sage: R.<x> = PolynomialRing(ZZ)
           sage: A.<Dx> = OreAlgebra(R)
           sage: op = (x+6)*Dx + 1
@@ -215,7 +214,7 @@ class OreOperator(RingElement):
           (x + 1)*Dx + 1
           sage: op2.parent()
           Univariate Ore algebra in Dx over Univariate Polynomial Ring in x over Finite Field of size 5
-
+        
         """
         R = self.base_ring()
         A = self.parent().change_constant_ring(K)

--- a/src/ore_algebra/ore_operator.py
+++ b/src/ore_algebra/ore_operator.py
@@ -184,11 +184,52 @@ class OreOperator(RingElement):
           Univariate Ore algebra in Dx over Fraction Field of Univariate Polynomial Ring in x over Rational Field
         
         """
-        if R == self.base_ring():
+        if R is self.base_ring():
             return self
         else:
             return self.parent().change_ring(R)(self)
 
+    def change_constant_ring(self, K):
+        r"""
+        Return a copy of this operator but with constant coefficients in K, if at all possible.
+
+        EXAMPLES:
+        
+          sage: from ore_algebra import *
+          sage: R.<x,y> = PolynomialRing(QQ)
+          sage: A.<Dx,Dy> = OreAlgebra(R)
+          sage: op = (x+6)*Dx^2 + 1/2*Dx*Dy
+          sage: op2 = op.change_constant_ring(GF(5)); op2
+          (x + 1)*Dx^2 + (-2)*Dx*Dy
+          sage: op2.parent()
+          Multivariate Ore algebra in Dx, Dy over Multivariate Polynomial Ring in x, y over Finite Field of size 5
+          sage: op = (1/x)*((x+6)*Dx^2 + 1/2*Dx*Dy)
+          sage: op2 = op.change_constant_ring(GF(5)); op2
+          (x + 1)/x*Dx^2 - 2/x*Dx*Dy
+          sage: op2.parent()
+          Multivariate Ore algebra in Dx, Dy over Fraction Field of Multivariate Polynomial Ring in x, y over Finite Field of size 5
+          sage: R.<x> = PolynomialRing(ZZ)
+          sage: A.<Dx> = OreAlgebra(R)
+          sage: op = (x+6)*Dx + 1
+          sage: op2 = op.change_constant_ring(GF(5)); op2
+          (x + 1)*Dx + 1
+          sage: op2.parent()
+          Univariate Ore algebra in Dx over Univariate Polynomial Ring in x over Finite Field of size 5
+
+        """
+        R = self.base_ring()
+        A = self.parent().change_constant_ring(K)
+        if K is R.base_ring():
+            return self
+        elif R.is_field():
+            d = {k: R(c).numerator().change_ring(K)/R(c).denominator().change_ring(K)
+                 for k,c in self.dict().items()}
+            return A(d)
+        else:
+            d = {k: R(c).change_ring(K) for k,c in self.dict().items()}
+            return A(d)
+            
+        
     def __iter__(self):
         return iter(self.list())
 

--- a/src/ore_algebra/ore_operator.py
+++ b/src/ore_algebra/ore_operator.py
@@ -199,15 +199,15 @@ class OreOperator(RingElement):
           sage: R.<x,y> = PolynomialRing(QQ)
           sage: A.<Dx,Dy> = OreAlgebra(R)
           sage: op = (x+6)*Dx^2 + 1/2*Dx*Dy
-          sage: op2 = op.change_constant_ring(GF(5)); op2
-          (x + 1)*Dx^2 + (-2)*Dx*Dy
+          sage: _ = var('t')
+          sage: K.<a> = NumberField(t^2-2)
+          sage: op2 = op.change_constant_ring(K)
           sage: op2.parent()
-          Multivariate Ore algebra in Dx, Dy over Multivariate Polynomial Ring in x, y over Finite Field of size 5
+          Multivariate Ore algebra in Dx, Dy over Multivariate Polynomial Ring in x, y over Number Field in a with defining polynomial t^2 - 2
           sage: op = (1/x)*((x+6)*Dx^2 + 1/2*Dx*Dy)
-          sage: op2 = op.change_constant_ring(GF(5)); op2
-          (x + 1)/x*Dx^2 - 2/x*Dx*Dy
+          sage: op2 = op.change_constant_ring(K)
           sage: op2.parent()
-          Multivariate Ore algebra in Dx, Dy over Fraction Field of Multivariate Polynomial Ring in x, y over Finite Field of size 5
+          Multivariate Ore algebra in Dx, Dy over Fraction Field of Multivariate Polynomial Ring in x, y over Number Field in a with defining polynomial t^2 - 2
           sage: R.<x> = PolynomialRing(ZZ)
           sage: A.<Dx> = OreAlgebra(R)
           sage: op = (x+6)*Dx + 1

--- a/src/ore_algebra/ore_operator.py
+++ b/src/ore_algebra/ore_operator.py
@@ -203,8 +203,9 @@ class OreOperator(RingElement):
           (x + 1)*Dx^2 + (-2)*Dx*Dy
           sage: op2.parent()
           Multivariate Ore algebra in Dx, Dy over Multivariate Polynomial Ring in x, y over Finite Field of size 5
-          sage: op = (1/x)*((x+6)*Dx^2 + 1/2*Dx*Dy); op2
-          sage: op2 = op.change_constant_ring(GF(5))
+          sage: op = (1/x)*((x+6)*Dx^2 + 1/2*Dx*Dy)
+          sage: op2 = op.change_constant_ring(GF(5)); op2
+          (x + 1)/x*Dx^2 - 2/x*Dx*Dy
           sage: op2.parent()
           Multivariate Ore algebra in Dx, Dy over Fraction Field of Multivariate Polynomial Ring in x, y over Finite Field of size 5
           sage: R.<x> = PolynomialRing(ZZ)


### PR DESCRIPTION
Hi,

This pull request includes methods to change the constant ring of an algebra or an operator: if A is the Ore algebra of differential operators over K(x,y), and L is a field that K can map into, A.change_constant_ring(L) is the same algebra but over L(x,y).

"Can map into" is a pragmatic criterion, for instance Q can map into GF(5), it will just raise an error if doing so attempts to do a division by 0.

In implementing this, I needed to make changes to the change_ring method, and in particular implement a change_ring method for the sigma and delta endomorphisms to make sure that their operands live in the correct ring.

Without those changes, with A = Ore algebra(QQ['x'],'Dx'), A.change_ring(GF(5)['x']) would fail.

I believe that the changes are harmless, but it cannot hurt to have another pair of eyes on it.

Best wishes,
Thibaut