### PR TITLE
Fix compatibility with Flint3

### DIFF
--- a/src/ore_algebra/analytic/naive_sum_c.pyx
+++ b/src/ore_algebra/analytic/naive_sum_c.pyx
@@ -26,7 +26,15 @@ from sage.structure.parent cimport Parent
 
 from sage.rings.real_arb import RBF
 
-cdef extern from "acb.h":
+cdef extern from *:
+    """
+    #include "flint/flint.h"
+    #if __FLINT_VERSION >= 3
+    #include "flint/acb.h"
+    #else
+    #include "acb.h"
+    #endif
+    """
     void acb_dot(acb_t res, const acb_t s, bint subtract, acb_srcptr x, long
             xstep, acb_srcptr y, long ystep, long len, long prec)
 


### PR DESCRIPTION
acb.h -> flint/acb.h

The Arb library is now included in Flint. This fix is necessary to install ore_algera in archlinux.

You can test with a docker image
```
podman run -ti archlinux:latest
pacman -Sy
pacman -S gcc pkgconf python-pkgconfig python-pip cython git maxima-ecl sagemath
rm /usr/lib/python3.11/EXTERNALLY-MANAGED
sage -pip install --user git+https://github.com/mkauers/ore_algebra.git # FAIL
sage -pip install --user git+https://github.com/lairez/ore_algebra.git # OK
```

