### PR TITLE
port to sage 10.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,6 @@
+import sys
+import warnings
+
 from setuptools import setup
 from setuptools import Command
 from setuptools import Extension
@@ -5,6 +8,7 @@ from Cython.Build import cythonize
 
 try:
     import sage.env
+    import sage.version
 except ImportError:
     raise ValueError("this package requires SageMath")
 
@@ -32,12 +36,25 @@ def do_cythonize():
             aliases = sage.env.cython_aliases(),
         )
 
-try:
-    from sage.misc.package_dir import cython_namespace_package_support
-    with cython_namespace_package_support():
+if list(map(int, sage.version.version.split('.')[:2])) < [10, 2]:
+    # Unfortunately, pip does not display this warning by default. But we will
+    # warn about this again when the user tries to call one of the affected
+    # functions.
+    warnings.warn(
+        f"Found SageMath version {sage.version.version}. The Cython extensions "
+        "in ore_algebra now require SageMath >= 10.2. The ore_algebra package "
+        "will be installed with Cython extensions disabled, making numerical "
+        "evaluation and related features slow. To use the full version of "
+        "ore_algebra, upgrade SageMath or downgrade ore_algebra to git commit "
+        "73a430aaf.")
+    extensions = []
+else:
+    try:
+        from sage.misc.package_dir import cython_namespace_package_support
+        with cython_namespace_package_support():
+            extensions = do_cythonize()
+    except ImportError:
         extensions = do_cythonize()
-except ImportError:
-    extensions = do_cythonize()
 
 setup(
     name = "ore_algebra",

--- a/src/ore_algebra/analytic/binary_splitting.py
+++ b/src/ore_algebra/analytic/binary_splitting.py
@@ -893,8 +893,7 @@ class MatrixRec(object):
             from . import binary_splitting_arb
             self.StepMatrix_class = binary_splitting_arb.StepMatrix_arb
         except ImportError:
-            logger.warning("Cython implementation unavailable, "
-                           "falling back to slower Python implementation")
+            utilities.warn_no_cython_extensions(logger, fallback=True)
             self.StepMatrix_class = StepMatrix_arb
         if _can_use_RBF(deq_Scalars, shift, *point_parents):
             dom = RealBallField(prec)

--- a/src/ore_algebra/analytic/binary_splitting_arb.pyx
+++ b/src/ore_algebra/analytic/binary_splitting_arb.pyx
@@ -67,11 +67,11 @@ class StepMatrix_arb(binary_splitting.StepMatrix_arb):
             # the inner polynomial to have valuation > 0.
             # TODO: Maybe use evaluate or evaluate2 instead when applicable.
             acb_poly_taylor_shift(
-                    val_pert.__poly,
-                    (<Polynomial_complex_arb> (rec.bwrec.coeff[i])).__poly,
+                    val_pert._poly,
+                    (<Polynomial_complex_arb> (rec.bwrec.coeff[i]))._poly,
                     n, prec)
             acb_poly_truncate(
-                    val_pert.__poly,
+                    val_pert._poly,
                     ord_log + mult)
             bwrec_n[i] = val_pert
         acb_clear(n)
@@ -79,7 +79,7 @@ class StepMatrix_arb(binary_splitting.StepMatrix_arb):
         den = ComplexBall.__new__(ComplexBall)
         den._parent = rec.bwrec.Scalars
 
-        lc = (<Polynomial_complex_arb> (bwrec_n[0])).__poly
+        lc = (<Polynomial_complex_arb> (bwrec_n[0]))._poly
         for i in range(mult):
             assert acb_contains_zero(acb_poly_get_coeff_ptr(lc, i)), "!= 0"
         acb_poly_shift_right(lc, lc, mult)
@@ -134,8 +134,8 @@ class StepMatrix_arb(binary_splitting.StepMatrix_arb):
 
         for i in range(rec.ordrec):
             acb_poly_mullow(
-                    (<Polynomial_complex_arb> (bwrec_n[1+i])).__poly,
-                    (<Polynomial_complex_arb> (bwrec_n[1+i])).__poly,
+                    (<Polynomial_complex_arb> (bwrec_n[1+i]))._poly,
+                    (<Polynomial_complex_arb> (bwrec_n[1+i]))._poly,
                     lc, ord_log, prec)
 
         # TODO: implement the gcd of Gaussian integers represented as acb
@@ -160,7 +160,7 @@ class StepMatrix_arb(binary_splitting.StepMatrix_arb):
         seqs = [[zpol._new() for _ in range(rec.ordrec)]
                 for _ in range(rec.ordrec)]
         for k in range(1, rec.ordrec + 1):
-            acb_poly_one((<Polynomial_complex_arb> (seqs[-k][-k])).__poly)
+            acb_poly_one((<Polynomial_complex_arb> (seqs[-k][-k]))._poly)
 
         return zero, row, seqs
 
@@ -188,8 +188,8 @@ class StepMatrix_arb(binary_splitting.StepMatrix_arb):
 
         for q in range(ord_log):
             for p in range(ord_diff):
-                a = acb_poly_get_coeff_ptr(pow_num.__poly, p)
-                b = acb_poly_get_coeff_ptr(mynum.__poly, q)
+                a = acb_poly_get_coeff_ptr(pow_num._poly, p)
+                b = acb_poly_get_coeff_ptr(mynum._poly, q)
                 c = <ComplexBall> ((<list> (<list> psum)[q])[p])
                 if a != NULL and b != NULL:
                     acb_addmul(c.value, a, b, prec)
@@ -223,17 +223,17 @@ class StepMatrix_arb(binary_splitting.StepMatrix_arb):
         for k in range(1, len(bwrec_n)):
             coef = <Polynomial_complex_arb> (bwrec_n[k])
             mynum = <Polynomial_complex_arb> (num[len_num-k])
-            acb_poly_mullow(tmppol, coef.__poly, mynum.__poly, ord_log, prec)
+            acb_poly_mullow(tmppol, coef._poly, mynum._poly, ord_log, prec)
             acb_poly_sub(u_n, u_n, tmppol, prec)
         acb_poly_clear(tmppol)
 
         for k in range(len_num - 1):
             acb_poly_scalar_mul(
-                    (<Polynomial_complex_arb> num[k]).__poly,
-                    (<Polynomial_complex_arb> num[k+1]).__poly,
+                    (<Polynomial_complex_arb> num[k])._poly,
+                    (<Polynomial_complex_arb> num[k+1])._poly,
                     rec_den_n.value, prec)
 
-        acb_poly_swap((<Polynomial_complex_arb> num[len_num-1]).__poly, u_n)
+        acb_poly_swap((<Polynomial_complex_arb> num[len_num-1])._poly, u_n)
         acb_poly_clear(u_n)
 
     @cython.boundscheck(False)
@@ -254,7 +254,7 @@ class StepMatrix_arb(binary_splitting.StepMatrix_arb):
         cdef unsigned long prec = Scalars.precision()
 
         cdef acb_poly_struct *low_pow_num # why isn't this working with _ptr?
-        low_pow_num = (<Polynomial_complex_arb> ((<list> low.pow_num)[i])).__poly
+        low_pow_num = (<Polynomial_complex_arb> ((<list> low.pow_num)[i]))._poly
         cdef Polynomial low_rec_mat = <Polynomial> (low.rec_mat)
 
         cdef acb_t high_den

--- a/src/ore_algebra/analytic/eval_poly_at_int.pyx
+++ b/src/ore_algebra/analytic/eval_poly_at_int.pyx
@@ -49,9 +49,9 @@ def cbf(pol, n, tgt):
     cdef long prec = _pol._parent._base._prec
 
     acb_zero(res.value)
-    for i in range(acb_poly_degree(_pol.__poly), -1, -1):
+    for i in range(acb_poly_degree(_pol._poly), -1, -1):
         acb_mul_si(res.value, res.value, _n, prec)
-        acb_add(res.value, res.value, acb_poly_get_coeff_ptr(_pol.__poly, i), prec)
+        acb_add(res.value, res.value, acb_poly_get_coeff_ptr(_pol._poly, i), prec)
 
     return res
 
@@ -62,11 +62,11 @@ cdef ZZX_c _nf(Polynomial_generic_dense pol, n) except *:
     cdef NumberFieldElement c
     cdef ZZX_c res
 
-    for i in range(len(pol.__coeffs) - 1, -1, -1):
+    for i in range(len(pol._coeffs) - 1, -1, -1):
         ZZX_mul_long(res, res, _n)
         c = pol.get_unsafe(i)
-        assert ZZ_IsOne(c.__denominator)
-        ZZX_add(res, res, c.__numerator)
+        assert ZZ_IsOne(c._denominator)
+        ZZX_add(res, res, c._numerator)
 
     return res
 
@@ -75,8 +75,8 @@ def nf(pol, n, tgt):
 
     cdef NumberFieldElement res
     res = (<NumberFieldElement> (<Ring> _pol._parent._base)._zero_element)._new()
-    ZZ_conv_from_int(res.__denominator, 1)
-    res.__numerator = _nf(_pol, n)
+    ZZ_conv_from_int(res._denominator, 1)
+    res._numerator = _nf(_pol, n)
     if tgt is _pol._parent._base:
         return res
     else:
@@ -92,7 +92,7 @@ cdef int _qnf(mpz_t a, mpz_t b, Polynomial_generic_dense pol, n) except -1:
     mpz_set_ui(a, 0)
     mpz_set_ui(b, 0)
 
-    for i in range(len(pol.__coeffs) - 1, -1, -1):
+    for i in range(len(pol._coeffs) - 1, -1, -1):
         mpz_mul_ui(a, a, _n)
         mpz_mul_ui(b, b, _n)
         c = pol.get_unsafe(i)
@@ -176,12 +176,12 @@ def qq_or_qqi_to_cbf(zzpols not None, n, tgt):
     fmpz_init(tmp)
 
     pol = <Polynomial_integer_dense_flint> (zzpols[0])
-    fmpz_poly_evaluate_fmpz(tmp, pol.__poly, _n)
+    fmpz_poly_evaluate_fmpz(tmp, pol._poly, _n)
     arb_set_fmpz(acb_realref(res.value), tmp)
 
     if len(zzpols) == 2:
         pol = <Polynomial_integer_dense_flint> (zzpols[1])
-        fmpz_poly_evaluate_fmpz(tmp, pol.__poly, _n)
+        fmpz_poly_evaluate_fmpz(tmp, pol._poly, _n)
         arb_set_fmpz(acb_imagref(res.value), tmp)
     else:
         arb_zero(acb_imagref(res.value))
@@ -201,12 +201,12 @@ def qq(pol, n, tgt):
     cdef fmpz_t tmp
     fmpz_init(tmp)
 
-    _fmpz_poly_evaluate_fmpz(tmp, fmpq_poly_numref(_pol.__poly),
-            fmpq_poly_length(_pol.__poly), _n)
+    _fmpz_poly_evaluate_fmpz(tmp, fmpq_poly_numref(_pol._poly),
+            fmpq_poly_length(_pol._poly), _n)
 
     cdef Rational res = <Rational> Rational.__new__(Rational)
     fmpz_get_mpz(mpq_numref(res.value), tmp)
-    assert fmpz_is_one(fmpq_poly_denref(_pol.__poly))
+    assert fmpz_is_one(fmpq_poly_denref(_pol._poly))
     mpz_set_si(mpq_denref(res.value), 1)
 
     fmpz_clear(tmp)

--- a/src/ore_algebra/analytic/local_solutions.py
+++ b/src/ore_algebra/analytic/local_solutions.py
@@ -195,7 +195,7 @@ class BwShiftRec(object):
         try:
             from . import eval_poly_at_int
         except ImportError:
-            warnings.warn("Cython code not found")
+            utilities.warn_no_cython_extensions(logger, fallback=True)
             return generic_eval, False
 
         if isinstance(self.Scalars, ComplexBallField):

--- a/src/ore_algebra/analytic/naive_sum.py
+++ b/src/ore_algebra/analytic/naive_sum.py
@@ -47,8 +47,7 @@ def cy_classes():
         from . import naive_sum_c
         return naive_sum_c.CoefficientSequence, naive_sum_c.PartialSum
     except ImportError:
-        warnings.warn("Cython implementation unavailable, "
-                      "falling back to slower Python implementation")
+        utilities.warn_no_cython_extensions(logger, fallback=True)
         return CoefficientSequence, PartialSum
 
 class CoefficientSequence(object):

--- a/src/ore_algebra/analytic/naive_sum_c.pyx
+++ b/src/ore_algebra/analytic/naive_sum_c.pyx
@@ -142,13 +142,13 @@ class PartialSum(naive_sum.PartialSum):
             poly = <Polynomial_complex_arb> Polynomial_complex_arb.__new__(Polynomial_complex_arb)
             poly._parent = (<Polynomial_complex_arb> (psum[k]))._parent
             acb_poly_scalar_mul(
-                    poly.__poly,
-                    (<Polynomial_complex_arb> jetpow).__poly,
+                    poly._poly,
+                    (<Polynomial_complex_arb> jetpow)._poly,
                     (<ComplexBall> last_0[k]).value,
                     prec)
             acb_poly_add(
-                    poly.__poly,
-                    (<Polynomial_complex_arb> (psum[k])).__poly,
-                    poly.__poly,
+                    poly._poly,
+                    (<Polynomial_complex_arb> (psum[k]))._poly,
+                    poly._poly,
                     prec)
             psum[k] = poly

--- a/src/ore_algebra/analytic/utilities.py
+++ b/src/ore_algebra/analytic/utilities.py
@@ -13,6 +13,8 @@ Miscellaneous utilities
 # http://www.gnu.org/licenses/
 
 import itertools
+import warnings
+
 from builtins import zip
 
 import sage.rings.complex_arb
@@ -286,3 +288,18 @@ def binomial_coefficients(s):
         for k in range(1, n + 1):
             binom[n][k] = binom[n-1][k-1] + binom[n-1][k]
     return binom
+
+def warn_no_cython_extensions(logger, *, fallback=False):
+    import sage.version
+    msg = "Cython extensions not found."
+    if fallback:
+        msg += " Falling back to slower Python implementation."
+    if list(map(int, sage.version.version.split('.')[:2])) < [10, 2]:
+        msg += (
+            f" (Hint: You are using SageMath version {sage.version.version}."
+            " The Cython extensions in this version of ore_algebra require"
+            " SageMath 10.2 or later."
+            " Consider upgrading SageMath or downgrading ore_algebra to git"
+            " commit 73a430aaf.)")
+    warnings.warn(msg, stacklevel=2)
+


### PR DESCRIPTION
Hi Manuel,

This is mainly about my code, but I thought you should be aware of it as it
affects the build system a little bit. The story is that due to some changes in
recent versions of cython, the last sage release renamed some private fields I
have to access from the cython code. It would be cumbersome to keep supporting
the old names, so I automatically disable the cython extensions at build time
under older sage versions.
