### PR TITLE
ruff UP004 : no need to inherit from object

### DIFF
--- a/src/ore_algebra/analytic/accuracy.py
+++ b/src/ore_algebra/analytic/accuracy.py
@@ -29,7 +29,7 @@ logger = logging.getLogger(__name__)
 class PrecisionError(Exception):
     pass
 
-class BoundCallbacks(object):
+class BoundCallbacks:
     r"""
     Used by StoppingCriterion.
     """
@@ -70,7 +70,7 @@ class BoundCallbacks(object):
         """
         raise NotImplementedError
 
-class StoppingCriterion(object):
+class StoppingCriterion:
     r"""
     Condition for dynamically deciding where to truncate a series.
 

--- a/src/ore_algebra/analytic/binary_splitting.py
+++ b/src/ore_algebra/analytic/binary_splitting.py
@@ -271,7 +271,7 @@ def PolynomialRing(base, var):
     else:
         return polyringconstr.PolynomialRing(base, var)
 
-class StepMatrix(object): # pylint: disable=attribute-defined-outside-init
+class StepMatrix: # pylint: disable=attribute-defined-outside-init
     r"""
     A structured matrix that maps a vector of s coefficients and a partial sum
     (both around some truncation index n) of a D-finite series to a similar
@@ -507,7 +507,7 @@ class StepMatrix_arb(StepMatrix):
                     for c in b:
                         assert c.is_exact()
 
-class SolutionColumn(object):
+class SolutionColumn:
     r"""
     Partially “unrolled” local canonical solutions.
 
@@ -719,7 +719,7 @@ class SolutionColumn(object):
         den = abs(IC_est(self.v.rec_den))*IR(self.v.pow_den[0])
         return num1*num2/den
 
-class MatrixRec(object):
+class MatrixRec:
     r"""
     A matrix recurrence simultaneously generating the coefficients and partial
     sums at one or more points of solutions of an ODE (with exponents in a

--- a/src/ore_algebra/analytic/bounds.py
+++ b/src/ore_algebra/analytic/bounds.py
@@ -160,7 +160,7 @@ class BoundPrecisionError(Exception):
 # Majorant series
 ######################################################################
 
-class MajorantSeries(object):
+class MajorantSeries:
     r"""
     A formal power series with nonnegative coefficients
     """
@@ -857,7 +857,7 @@ def _complex_roots(pol, IC):
 # - better take into account the range of derivatives needed at each step,
 # - allow ord to vary?
 
-class RatSeqBound(object):
+class RatSeqBound:
     r"""
     Bounds on the tails of a.e. rational sequences and their derivatives.
 
@@ -1515,7 +1515,7 @@ def bound_polynomials(pols, Poly):
     maj <<= val
     return maj
 
-class DiffOpBound(object):
+class DiffOpBound:
     r"""
     A “bound” on the “inverse” of a differential operator at a regular point.
 
@@ -2430,7 +2430,7 @@ class DiffOpBound(object):
         p.set_legend_options(handlelength=4, shadow=False)
         return p
 
-class MultiDiffOpBound(object):
+class MultiDiffOpBound:
     r"""
     Ad hoc wrapper for passing several DiffOpBounds to StopOnRigorousBound.
 

--- a/src/ore_algebra/analytic/context.py
+++ b/src/ore_algebra/analytic/context.py
@@ -16,7 +16,7 @@ import pprint
 
 from sage.rings.real_arb import RealBallField
 
-class Context(object):
+class Context:
     r"""
     Analytic continuation context
 

--- a/src/ore_algebra/analytic/deform.py
+++ b/src/ore_algebra/analytic/deform.py
@@ -511,7 +511,7 @@ def first_step(zs, z0, z1, orient, loops):
 # Global path deformation
 ######################################################################
 
-class DegenerateVoronoi(object):
+class DegenerateVoronoi:
     r"""
     Voronoi diagram of zero or more aligned points, in a format compatible (for
     our purposes) with the output of scipy.spatial.Voronoi.
@@ -538,7 +538,7 @@ class DegenerateVoronoi(object):
 
         self.hull = point_indices + list(reversed(point_indices[1:-1]))
 
-class VoronoiStep(object):
+class VoronoiStep:
     r"""
     A “combinatorial” step.
 
@@ -567,7 +567,7 @@ class VoronoiStep(object):
     def __repr__(self):
         return "{}→{}({})".format(self.v0, self.v1, self.ridge)
 
-class PathDeformer(object):
+class PathDeformer:
 
     def __init__(self, path, dop=None, max_subdivide=100):
         if dop is None: # then interpret path as a Path object
@@ -654,7 +654,7 @@ class PathDeformer(object):
         hull = [s for s in range(len(self.voronoi.points))
                 if -1 in self.voronoi.regions[self.voronoi.point_region[s]]]
         z0 = self.sing[hull[0]]
-        class Key(object):
+        class Key:
             def __init__(key, i):
                 key.i = i
             def __lt__(key0, key1, eps=eps):

--- a/src/ore_algebra/analytic/function.py
+++ b/src/ore_algebra/analytic/function.py
@@ -51,7 +51,7 @@ logger = logging.getLogger(__name__)
 
 RealPolApprox = collections.namedtuple('RealPolApprox', ['pol', 'prec'])
 
-class DFiniteFunction(object):
+class DFiniteFunction:
     r"""
     At the moment, this class just provides a simple caching mechanism for
     repeated evaluations of a D-Finite function on the real line. It may

--- a/src/ore_algebra/analytic/local_solutions.py
+++ b/src/ore_algebra/analytic/local_solutions.py
@@ -102,7 +102,7 @@ def _mygcd_ZZ(seq):
 if not hasattr(Integer, '_gcd'): # Sage < 9.3
     _mygcd_ZZ = gcd
 
-class BwShiftRec(object):
+class BwShiftRec:
     r"""
     A recurrence relation, written in terms of the backward shift operator.
 
@@ -288,7 +288,7 @@ class MultDict(dict):
     def __missing__(self, k):
         return 0
 
-class LogSeriesInitialValues(object):
+class LogSeriesInitialValues:
     r"""
     Initial values defining a logarithmic series.
 
@@ -524,7 +524,7 @@ class sort_key_by_asympt:
                 -other.leftmost.as_algebraic().imag().sign())
         return self.leftmost.as_algebraic().imag() < 0
 
-class LocalBasisMapper(object):
+class LocalBasisMapper:
     r"""
     Utility class for iterating over the canonical local basis of solutions of
     an operator.
@@ -831,7 +831,7 @@ def simplify_exponent(e):
             pass
     return e
 
-class LogMonomial(object):
+class LogMonomial:
 
     def __init__(self, dx, expo, shift, k):
         self.dx = dx

--- a/src/ore_algebra/analytic/naive_sum.py
+++ b/src/ore_algebra/analytic/naive_sum.py
@@ -50,7 +50,7 @@ def cy_classes():
         utilities.warn_no_cython_extensions(logger, fallback=True)
         return CoefficientSequence, PartialSum
 
-class CoefficientSequence(object):
+class CoefficientSequence:
 
     def __init__(self, Intervals, ini, ordrec, real):
         r"""
@@ -139,7 +139,7 @@ class CoefficientSequence(object):
 
         return err
 
-class PartialSum(object):
+class PartialSum:
 
     def __init__(self, cseq, Jets, ord, pt, pt_opts, IR):
 

--- a/src/ore_algebra/analytic/utilities.py
+++ b/src/ore_algebra/analytic/utilities.py
@@ -39,7 +39,7 @@ from sage.structure.sequence import Sequence
 # Timing
 ######################################################################
 
-class Clock(object):
+class Clock:
     def __init__(self, name="time"):
         self.name = name
         self._sum = 0.
@@ -57,7 +57,7 @@ class Clock(object):
         self._sum += cputime(self._tic)
         self._tic = None
 
-class Stats(object):
+class Stats:
     def __repr__(self):
         return ", ".join(str(clock) for clock in self.__dict__.values()
                                     if isinstance(clock, Clock))

--- a/src/ore_algebra/examples/iint.py
+++ b/src/ore_algebra/examples/iint.py
@@ -235,7 +235,7 @@ def iint_value(dop, ini, eps=1e-16, **kwds):
 
 _one = ZZ.one()
 
-class _F(object):
+class _F:
     def __getitem__(self, a):
         if a == 1:
             return 1/(1-x)

--- a/src/ore_algebra/ideal.py
+++ b/src/ore_algebra/ideal.py
@@ -1001,7 +1001,7 @@ class OreLeftIdeal(Ideal_nc):
     creative_telescoping = ct
 
 
-class MonomialIterator(object):
+class MonomialIterator:
     """
     Iterate in increasing order over the monomials that are below some staircase that is determined in parallel to the iteration.
     Tool for FGLM.

--- a/src/ore_algebra/ore_algebra.py
+++ b/src/ore_algebra/ore_algebra.py
@@ -147,7 +147,7 @@ def is_suitable_base_ring(R):
     else:
         return False
 
-class Sigma_class(object):
+class Sigma_class:
     r"""
     A ring endomorphism for suitable rings. 
 
@@ -397,7 +397,7 @@ class Sigma_class(object):
         sigma_inv.__inverse = self
         return sigma_inv
 
-class Delta_class(object):
+class Delta_class:
     r"""
     A skew-derivation for suitable rings. 
 


### PR DESCRIPTION
scripted using

`ruff --fix --select=UP004 .`