### PR TITLE
Restore FLINT < 3.4 compatibility in pitvdm_stdpts

### DIFF
--- a/src/ore_algebra/analytic/dac_sum_c.pyx
+++ b/src/ore_algebra/analytic/dac_sum_c.pyx
@@ -13,9 +13,7 @@ from sage.libs.flint.acb_mat cimport *
 from sage.libs.flint.acb_poly cimport *
 from sage.libs.flint.arb cimport *
 from sage.libs.flint.arf cimport arf_is_nan, arf_set_mag
-from sage.libs.flint.fmpq cimport *
 from sage.libs.flint.fmpq_poly cimport *
-from sage.libs.flint.fmpq_vec cimport *
 from sage.libs.flint.fmpz cimport *
 from sage.libs.flint.fmpz_mat cimport *
 from sage.libs.flint.fmpz_poly cimport *
@@ -26,11 +24,95 @@ from sage.libs.flint.mag cimport *
 from sage.libs.flint.gr_mat cimport gr_mat_pascal
 
 cdef extern from "flint_wrap.h":
-    int _fmpq_poly_interpolate_fmpq_vec(fmpz * poly, fmpz_t den, const fmpq * xs, const fmpq * ys, slong n)
     void gr_ctx_init_fmpz(gr_ctx_t ctx) noexcept
     void GR_MUST_SUCCEED(int status) noexcept
     mp_limb_t FLINT_BIT_COUNT(mp_limb_t x) noexcept
     cdef slong WORD_MAX
+
+
+cdef extern from *:
+    """
+    /* Compatibility shim for the inverse-transpose-Vandermonde computation in
+     * pitvdm_stdpts: FLINT 3.4 dropped _fmpq_poly_interpolate_fmpz_vec and
+     * added _fmpq_poly_interpolate_fmpq_vec, so we keep two implementations
+     * with identical observable behaviour and select between them at compile
+     * time on __FLINT_RELEASE. The points used here are integer, so both
+     * formulations are mathematically equivalent. */
+    #include "flint_wrap.h"
+
+    #if __FLINT_RELEASE >= 30400
+    static inline void _oa_pitvdm_stdpts_impl(fmpz_mat_t matnum, fmpz_t matden, slong n) {
+        slong i, j;
+        fmpz_t tmp;
+        fmpz_init(tmp);
+        fmpq *points = _fmpq_vec_init(2*n - 1);
+        fmpq *values = _fmpq_vec_init(2*n - 1);
+        fmpz *rowden = _fmpz_vec_init(n);
+        fmpq_zero(points);
+        for (i = 1; i < n; i++) {
+            fmpq_set_si(points + 2*i - 1,  i, 1);
+            fmpq_set_si(points + 2*i,     -i, 1);
+        }
+        /* FIXME This repeats essentially the same computation n times.
+         * (And we could also share some work between different values of n by
+         * working in the Newton basis...) */
+        for (i = 0; i < n; i++) {
+            j = (i == 0) ? 0 : 2*i - 1;
+            fmpq_one(values + j);
+            _fmpq_poly_interpolate_fmpq_vec(fmpz_mat_entry(matnum, i, 0),
+                                            rowden + i, points, values, 2*n - 1);
+            fmpq_zero(values + j);
+        }
+        _fmpz_vec_lcm(matden, rowden, n);
+        for (i = 0; i < n; i++) {
+            fmpz_divexact(tmp, matden, rowden + i);
+            _fmpz_vec_scalar_mul_fmpz(fmpz_mat_entry(matnum, i, 0),
+                                      fmpz_mat_entry(matnum, i, 0),
+                                      2*n - 1, tmp);
+        }
+        _fmpz_vec_clear(rowden, n);
+        _fmpq_vec_clear(values, 2*n - 1);
+        _fmpq_vec_clear(points, 2*n - 1);
+        fmpz_clear(tmp);
+    }
+    #else  /* __FLINT_RELEASE < 30400 */
+    static inline void _oa_pitvdm_stdpts_impl(fmpz_mat_t matnum, fmpz_t matden, slong n) {
+        slong i, j;
+        fmpz_t tmp;
+        fmpz_init(tmp);
+        fmpz *points = _fmpz_vec_init(2*n - 1);
+        fmpz *values = _fmpz_vec_init(2*n - 1);
+        fmpz *rowden = _fmpz_vec_init(n);
+        fmpz_zero(points);
+        for (i = 1; i < n; i++) {
+            fmpz_set_si(points + 2*i - 1,  i);
+            fmpz_set_si(points + 2*i,     -i);
+        }
+        /* FIXME This repeats essentially the same computation n times.
+         * (And we could also share some work between different values of n by
+         * working in the Newton basis...) */
+        for (i = 0; i < n; i++) {
+            j = (i == 0) ? 0 : 2*i - 1;
+            fmpz_one(values + j);
+            _fmpq_poly_interpolate_fmpz_vec(fmpz_mat_entry(matnum, i, 0),
+                                            rowden + i, points, values, 2*n - 1);
+            fmpz_zero(values + j);
+        }
+        _fmpz_vec_lcm(matden, rowden, n);
+        for (i = 0; i < n; i++) {
+            fmpz_divexact(tmp, matden, rowden + i);
+            _fmpz_vec_scalar_mul_fmpz(fmpz_mat_entry(matnum, i, 0),
+                                      fmpz_mat_entry(matnum, i, 0),
+                                      2*n - 1, tmp);
+        }
+        _fmpz_vec_clear(rowden, n);
+        _fmpz_vec_clear(values, 2*n - 1);
+        _fmpz_vec_clear(points, 2*n - 1);
+        fmpz_clear(tmp);
+    }
+    #endif
+    """
+    void _oa_pitvdm_stdpts_impl(fmpz_mat_t matnum, fmpz_t matden, slong n) noexcept
 
 from sage.rings.complex_arb cimport ComplexBall
 from sage.rings.polynomial.polynomial_complex_arb cimport Polynomial_complex_arb
@@ -1780,38 +1862,10 @@ cdef void pitvdm_stdpts(fmpz_mat_t matnum, fmpz_t matden, slong n) noexcept:
     (The entry in column 0 ≤ j < 2n-1 of the row associated to -i is equal to
     (-1)^j times the corresponding entry in the row associated to i.)
     """
-    cdef slong i, j
     assert n >= 1
     assert fmpz_mat_nrows(matnum) == n
-    assert fmpz_mat_ncols(matnum) == 2*n-1
-    cdef fmpz_t tmp
-    fmpz_init(tmp)
-    cdef fmpq *points = _fmpq_vec_init(2*n-1)
-    cdef fmpq *values = _fmpq_vec_init(2*n-1)
-    cdef fmpz *rowden = _fmpz_vec_init(n)
-    fmpq_zero(points)
-    for i in range(1, n):
-        fmpq_set_si(points + 2*i - 1,  i, 1)
-        fmpq_set_si(points + 2*i,     -i, 1)
-    # FIXME This repeats essentially the same computation n times.
-    # (And we could also share some work between different values of n by
-    # working in the Newton basis...)
-    for i in range(n):
-        j = 0 if i == 0 else 2*i - 1
-        fmpq_one(values + j)
-        _fmpq_poly_interpolate_fmpq_vec(fmpz_mat_entry(matnum, i, 0),
-                                        rowden + i, points, values, 2*n-1)
-        fmpq_zero(values + j)
-    _fmpz_vec_lcm(matden, rowden, n)
-    for i in range(n):
-        fmpz_divexact(tmp, matden, rowden + i)
-        _fmpz_vec_scalar_mul_fmpz(fmpz_mat_entry(matnum, i, 0),
-                                  fmpz_mat_entry(matnum, i, 0),
-                                  2*n-1, tmp)
-    _fmpz_vec_clear(rowden, n)
-    _fmpq_vec_clear(values, 2*n-1)
-    _fmpq_vec_clear(points, 2*n-1)
-    fmpz_clear(tmp)
+    assert fmpz_mat_ncols(matnum) == 2*n - 1
+    _oa_pitvdm_stdpts_impl(matnum, matden, n)
 
 
 cdef void eval_reverse_stdpts(acb_ptr val, slong n, const acb_poly_struct *pol,


### PR DESCRIPTION
Commit ba8b58e ("fix cython summation code to work with recent flint versions") swapped `pitvdm_stdpts` over to `_fmpq_poly_interpolate_fmpq_vec` and the `_fmpq_vec_*` helpers, which require **FLINT ≥ 3.4**. On FLINT 3.3.x — still bundled with SageMath 10.8 — the wheel installs cleanly because shared-library compilation does not flag undefined references, but the first import of `ore_algebra.analytic.dac_sum_c` fails at runtime:

```
ImportError: .../ore_algebra/analytic/dac_sum_c.cpython-312-x86_64-linux-gnu.so:
    undefined symbol: _fmpq_poly_interpolate_fmpq_vec
```

This in turn breaks any downstream package that touches `dac_sum_c`, e.g. `lefschetz_family`.

## Reproducer (Sage 10.8, FLINT 3.3.1)

```bash
sage -pip install --no-build-isolation git+https://github.com/mkauers/ore_algebra.git
sage -c 'from ore_algebra.analytic.dac_sum_c import DACUnroller'
# → ImportError: undefined symbol: _fmpq_poly_interpolate_fmpq_vec
```

The regression is masked when pip is allowed build isolation, because the build env then pulls in `passagemath-flint` (which bundles newer FLINT headers) and the symbol gets declared at compile time even when the runtime libflint does not provide it. `--no-build-isolation`, recommended in lefschetz-family's README, makes the failure deterministic.

## Two possible fixes

The branch attached to this PR (`flint-pre-3.4-compat`) implements **Option A**. **Option B** is a much smaller patch and may be preferred if dropping support for FLINT < 3.4 is acceptable. Happy to switch heads if you'd rather have B.

### Option A — keep both formulations behind `__FLINT_RELEASE`  *(this branch)*

Move the body of `pitvdm_stdpts` into an inline-C shim that selects between the post-ba8b58e implementation (`_fmpq_poly_interpolate_fmpq_vec` + `_fmpq_vec_*`) and the pre-ba8b58e implementation (`_fmpq_poly_interpolate_fmpz_vec` + `_fmpz_vec_*`) at compile time on `__FLINT_RELEASE` (declared by `flint/flint.h`). The interpolation points (`0, ±1, ±2, …`) are integer either way, so the two formulations are mathematically equivalent. The shim uses a `cdef extern from *: """ … """` block to avoid Cython's deprecated `IF/ELSE` directive. The two now-unused `from sage.libs.flint.{fmpq,fmpq_vec} cimport *` lines added by ba8b58e are also dropped.

**Pros:** ore_algebra keeps working on Sage 10.8 today.
**Cons:** ~90 lines of duplicated C carried in-tree until FLINT 3.4 is the floor everywhere.

### Option B — declare FLINT ≥ 3.4 a build requirement  *(alternative, ~6 lines)*

Fail loudly at build time when FLINT is too old, instead of producing a wheel that ImportErrors at first use:

```cython
# near the top of dac_sum_c.pyx, after the existing `cdef extern from "flint_wrap.h":` block

cdef extern from *:
    """
    #include "flint_wrap.h"
    #if __FLINT_RELEASE < 30400
    #error "ore_algebra requires FLINT >= 3.4 since commit ba8b58e. SageMath 10.8 ships FLINT 3.3.1; upgrade to SageMath 10.10+ (or build against FLINT 3.4+ directly)."
    #endif
    """
```

**Pros:** zero long-term maintenance burden; the `#error` makes the diagnosis obvious to anyone who hits it.
**Cons:** users on Sage 10.8 / FLINT 3.3.x have to either upgrade or pin ore_algebra to the parent of ba8b58e (`afbe4dad50bd63f5b2ce112193555d6f9740e0d3`).

If you'd like, I can swap this PR's branch over to Option B; just say the word.

## Test

Both options have been built and imported cleanly on:

- SageMath 10.8 + FLINT 3.3.1 (where current master fails). With Option A: `from ore_algebra.analytic.dac_sum_c import DACUnroller` succeeds, and downstream `from lefschetz_family import Hypersurface` works. With Option B: the build aborts immediately with the `#error` text and the user is pointed at an unambiguous fix.

The Option-A `>= 30400` branch is bit-identical to ba8b58e's body, so behaviour on FLINT ≥ 3.4 is unchanged in either option.
